### PR TITLE
fix(workflow): Grant write permissions to workflow

### DIFF
--- a/.github/workflows/daily-game-generation.yml
+++ b/.github/workflows/daily-game-generation.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This change adds `permissions: contents: write` to the GitHub Actions workflow file. This is necessary to allow the action to commit and push changes to the repository, which was previously failing with a 403 error.