### PR TITLE
fix(workflow): Use github-pages environment

### DIFF
--- a/.github/workflows/daily-game-generation.yml
+++ b/.github/workflows/daily-game-generation.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: github-pages
     permissions:
       contents: write
 


### PR DESCRIPTION
The workflow was failing to access the GEMINI_API_KEY because it was not running in the environment where the secret was stored. This change configures the build job to use the `github-pages` environment, allowing it to access the necessary API key secret.